### PR TITLE
Simplifying travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,8 @@
-language: erlang
+language: elixir
 notifications:
   email: false
-
-env:
-  - ELIXIR="v1.0.0"
-  - ELIXIR="v1.0.1"
 otp_release:
   - 17.0
   - 17.1
-install: mix deps.get
-before_install:
-  - mkdir -p vendor/elixir
-  - wget -q https://github.com/elixir-lang/elixir/releases/download/$ELIXIR/Precompiled.zip && unzip -qq Precompiled.zip -d vendor/elixir
-  - export PATH="$PATH:$PWD/vendor/elixir/bin"
-  - export MIX_ENV=test
-  - mix local.hex --force
-script: mix test
+  - 17.3
+  - 17.4


### PR DESCRIPTION
I will leave version `17.0` and `17.1` in there just in case you still want to run tests against those versions.
